### PR TITLE
Use production branch for testing official package

### DIFF
--- a/servicefabric/Test/azuredeploy.parameters.json
+++ b/servicefabric/Test/azuredeploy.parameters.json
@@ -72,7 +72,7 @@
       "value": ""
     },
     "scriptBaseUrl": {
-      "value": "https://raw.githubusercontent.com/LingyunSu/AzureStack-QuickStart-Templates/sf_gallery_stable/ServiceFabricGalleryItem/Microsoft.ServiceFabricCluster/DeploymentTemplates/"
+      "value": "https://raw.githubusercontent.com/msazurestackworkloads/azurestack-gallery/master/servicefabric/Microsoft.ServiceFabricCluster/DeploymentTemplates/"
     }
   }
 }


### PR DESCRIPTION
This should be updated to run against master branch. We need to maintain different versions of 'scriptBaseUrl' in master test and staging test.