### PR TITLE
Capture error in log

### DIFF
--- a/AKSEngine-E2E/Template/script.sh
+++ b/AKSEngine-E2E/Template/script.sh
@@ -493,7 +493,7 @@ log_level -i "SUBSCRIPTION_ID: $SUBSCRIPTION_ID"
 log_level -i "TENANT_ID: $TENANT_ID"
 log_level -i "------------------------------------------------------------------------"
 
-make test-kubernetes > deploy_test_results
+make test-kubernetes &> deploy_test_results
 
 RESULT=$?
 


### PR DESCRIPTION
Changes in this PR help captures the error from the k8s cluster provisioning during AKS Upstream Tests.